### PR TITLE
Drop FORMLANDER_ENV=production from Dockerfile (finishes #35)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ RUN apk add --no-cache ca-certificates tzdata curl && \
 
 COPY --from=builder /src/formlander /usr/local/bin/formlander
 
-ENV FORMLANDER_ENV=production \
-  FORMLANDER_PORT=8080 \
+ENV FORMLANDER_PORT=8080 \
   FORMLANDER_DATA_DIR=/app/storage \
   FORMLANDER_LOGS_DIR=/app/storage/logs \
   FORMLANDER_SESSION_TIMEOUT_SECONDS=1800

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ docker run -d \
 
 **Important:** Use the same `FORMLANDER_SESSION_SECRET` value across restarts to prevent logging out all users.
 
+**Production deploys:** add `-e FORMLANDER_ENV=production` only if Formlander is reachable over HTTPS (TLS terminator like Caddy/Nginx in front). Production marks the session cookie `Secure`, so plain-HTTP setups will silently drop the cookie and login will appear to fail. The default is `development`, which is safe for any HTTP setup.
+
 Access the admin dashboard at `http://localhost:8080` with default credentials:
 - Email: `admin@formlander.local`
 - Password: `formlander` (you'll be prompted to change this on first login)


### PR DESCRIPTION
Follow-up to #36.

v3.0.2 made `development` the default in code, but the Dockerfile still baked `ENV FORMLANDER_ENV=production` — so Docker users (including the reporter of #35) never hit the new default and kept getting `Secure` session cookies on plain HTTP, which silently breaks login.

Verified by pulling v3.0.2, running the reporter's exact compose, and inspecting the `Set-Cookie`: still has `secure`.

This PR strips the line from the Dockerfile. Docker users now opt into production explicitly, same as everyone else. README updated with a note about adding the env var when fronted by HTTPS.

## Test plan

- [x] Verified v3.0.2 image still ships `Secure` cookie on plain HTTP
- [ ] After v3.0.3 release: re-run the reporter's exact docker-compose and confirm cookie has no `secure` flag and login completes