### PR TITLE
Restore FORMLANDER_ENV=production in Dockerfile (v3.0.4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ RUN apk add --no-cache ca-certificates tzdata curl && \
 
 COPY --from=builder /src/formlander /usr/local/bin/formlander
 
-ENV FORMLANDER_PORT=8080 \
+ENV FORMLANDER_ENV=production \
+  FORMLANDER_PORT=8080 \
   FORMLANDER_DATA_DIR=/app/storage \
   FORMLANDER_LOGS_DIR=/app/storage/logs \
   FORMLANDER_SESSION_TIMEOUT_SECONDS=1800

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker run -d \
 
 **Important:** Use the same `FORMLANDER_SESSION_SECRET` value across restarts to prevent logging out all users.
 
-**Production deploys:** add `-e FORMLANDER_ENV=production` only if Formlander is reachable over HTTPS (TLS terminator like Caddy/Nginx in front). Production marks the session cookie `Secure`, so plain-HTTP setups will silently drop the cookie and login will appear to fail. The default is `development`, which is safe for any HTTP setup.
+**HTTPS is required.** The Docker image runs in production mode, which marks the session cookie `Secure`. Without TLS in front (Caddy, Nginx, Traefik, etc.) browsers silently drop the cookie and login appears to fail. The bundled `install.sh` sets up Caddy with automatic certificates; if you roll your own with docker-compose, put a TLS terminator in front of `:8080`.
 
 Access the admin dashboard at `http://localhost:8080` with default credentials:
 - Email: `admin@formlander.local`
@@ -127,7 +127,7 @@ Formlander uses [Viper](https://github.com/spf13/viper) for flexible configurati
 - `FORMLANDER_SESSION_SECRET` - HMAC secret for signing session cookies (fixed default in dev/test)
 
 **Optional Environment Variables:**
-- `FORMLANDER_ENV` - Environment mode: `development`, `production` (default: `development`)
+- `FORMLANDER_ENV` - Environment mode: `development`, `production` (default: `development` for binary / `go run`; the Docker image sets `production`)
 - `FORMLANDER_PORT` - HTTP port (default: `8080`)
 - `FORMLANDER_LOG_LEVEL` - Log level: `debug`, `info`, `warn`, `error` (default: `error`)
 - `FORMLANDER_DATA_DIR` - Data directory path (default: `./storage`)


### PR DESCRIPTION
Reverts the Dockerfile change from #37.

PR #37 stripped `ENV FORMLANDER_ENV=production` from the Dockerfile on the assumption that production should be opt-in for Docker users. That assumption was wrong.

**What broke:** cartridge loads templates from disk in development mode (`html.New("web/templates", ".html")`). The Docker image only ships templates embedded in the binary — there's no `web/templates` directory on the container filesystem. Every authenticated page 500'd:

```
failed to render: lstat web/templates: no such file or directory
```

**The correct framing:** Docker is production-only. Development means running the binary or `go run` against the source tree, where `web/templates` exists. The code-level default-to-development (from #36) still helps that local dev path — only the Dockerfile change in #37 was wrong.

For self-hosters on plain HTTP, the answer is HTTPS in front (Caddy / Nginx / Traefik), not flipping the env to development. README updated to make that unambiguous.

## Test plan

- [x] Verified v3.0.3 (without this revert): templates 500, auth pages broken
- [ ] After v3.0.4 release: production-mode flow works end-to-end with HTTPS-in-front simulation (`X-Forwarded-Proto: https`) — login succeeds, Secure cookie set, change-password page renders