### PR TITLE
feat: SMTP mailer provider alongside Mailgun

### DIFF
--- a/e2e/003-mailers.spec.js
+++ b/e2e/003-mailers.spec.js
@@ -18,28 +18,37 @@ test.describe("Mailer Profiles", () => {
     }
   });
 
-  test("1. Create mailer profile", async ({ page }) => {
-    helpers.log("=== Creating Mailer Profile ===");
+  test("1. Create SMTP mailer profile", async ({ page }) => {
+    helpers.log("=== Creating SMTP Mailer Profile ===");
 
     await helpers.navigateTo("/admin/settings/mailers");
-    await page.click('text=New Profile');
+    await page.click("text=New Profile");
     await page.waitForLoadState("networkidle");
 
-    // Fill mailer profile details
-    await page.fill('input[name="name"]', "Test Mailgun");
-    await page.fill('input[name="api_key"]', "key-test-mailgun-key-12345");
-    await page.fill('input[name="domain"]', "mg.example.com");
-    await page.fill('input[name="default_from_name"]', "Formlander");
+    // SMTP is the default provider, so its fields are the visible ones.
+    await page.fill('input[name="name"]', "Test SMTP");
+    await page.fill('input[name="smtp_host"]', "smtp.example.com");
+    await page.fill('input[name="smtp_username"]', "smtp-user");
+    await page.fill('input[name="smtp_password"]', "smtp-pass");
     await page.fill('input[name="default_from_email"]', "noreply@example.com");
 
     await page.click('button[type="submit"]');
     await page.waitForLoadState("networkidle");
 
-    // Verify we're on a mailer-related page
     const url = page.url();
     expect(url).toContain("/admin/settings/mailers");
 
-    helpers.log("✅ Mailer profile created");
+    helpers.log("✅ SMTP mailer profile created");
+  });
+
+  test("1b. Selecting Mailgun reveals its fields", async ({ page }) => {
+    await helpers.navigateTo("/admin/settings/mailers/new");
+    await page.waitForLoadState("networkidle");
+
+    // SMTP default -> the Mailgun API key field is hidden until selected.
+    await expect(page.locator('input[name="api_key"]')).toBeHidden();
+    await page.selectOption('select[name="provider"]', "mailgun");
+    await expect(page.locator('input[name="api_key"]')).toBeVisible();
   });
 
   test("2. View mailer profiles list", async ({ page }) => {

--- a/internal/http/mailers.go
+++ b/internal/http/mailers.go
@@ -12,6 +12,16 @@ import (
 	"formlander/internal/integrations"
 )
 
+// parseSMTPPort converts the submitted port to an int, defaulting to 587
+// (submission/STARTTLS) when the field is left blank.
+func parseSMTPPort(s string) int {
+	if s == "" {
+		return 587
+	}
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
 // MailerProfileList shows all mailer profiles.
 func MailerProfileList(ctx *cartridge.Context) error {
 	db := ctx.DB()
@@ -49,6 +59,11 @@ func MailerProfileCreate(ctx *cartridge.Context) error {
 		DefaultFromName:  ctx.FormValue("default_from_name"),
 		DefaultFromEmail: ctx.FormValue("default_from_email"),
 		DefaultsJSON:     ctx.FormValue("defaults_json"),
+		SMTPHost:         ctx.FormValue("smtp_host"),
+		SMTPPort:         parseSMTPPort(ctx.FormValue("smtp_port")),
+		SMTPUsername:     ctx.FormValue("smtp_username"),
+		SMTPPassword:     ctx.FormValue("smtp_password"),
+		SMTPEncryption:   ctx.FormValue("smtp_encryption"),
 	}
 
 	_, err := integrations.CreateMailerProfile(logger, db, params)
@@ -128,6 +143,11 @@ func MailerProfileUpdate(ctx *cartridge.Context) error {
 		DefaultFromName:  ctx.FormValue("default_from_name"),
 		DefaultFromEmail: ctx.FormValue("default_from_email"),
 		DefaultsJSON:     ctx.FormValue("defaults_json"),
+		SMTPHost:         ctx.FormValue("smtp_host"),
+		SMTPPort:         parseSMTPPort(ctx.FormValue("smtp_port")),
+		SMTPUsername:     ctx.FormValue("smtp_username"),
+		SMTPPassword:     ctx.FormValue("smtp_password"),
+		SMTPEncryption:   ctx.FormValue("smtp_encryption"),
 	}
 
 	profile, err := integrations.UpdateMailerProfile(logger, db, uint(profileID), params)

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -10,7 +10,7 @@ import (
 type MailerProfile struct {
 	ID               uint   `gorm:"primaryKey"`
 	Name             string `gorm:"size:255;not null;uniqueIndex"`
-	Provider         string `gorm:"size:50;not null;default:'mailgun'"` // mailgun, smtp, etc.
+	Provider         string `gorm:"size:50;not null;default:'smtp'"` // smtp (default), mailgun
 	APIKey           string `gorm:"type:text"`                          // Mailgun: secret credential
 	Domain           string `gorm:"size:255"`                           // Mailgun: sending domain
 	DefaultFromName  string `gorm:"size:255"`

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -11,13 +11,19 @@ type MailerProfile struct {
 	ID               uint   `gorm:"primaryKey"`
 	Name             string `gorm:"size:255;not null;uniqueIndex"`
 	Provider         string `gorm:"size:50;not null;default:'mailgun'"` // mailgun, smtp, etc.
-	APIKey           string `gorm:"type:text"`                          // Secret credential
-	Domain           string `gorm:"size:255"`
+	APIKey           string `gorm:"type:text"`                          // Mailgun: secret credential
+	Domain           string `gorm:"size:255"`                           // Mailgun: sending domain
 	DefaultFromName  string `gorm:"size:255"`
 	DefaultFromEmail string `gorm:"size:255"`
 	DefaultsJSON     string `gorm:"type:text"` // JSON: tags, template, headers
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	// SMTP provider fields (null for mailgun profiles).
+	SMTPHost       string `gorm:"size:255"`
+	SMTPPort       int    `gorm:"default:587"`
+	SMTPUsername   string `gorm:"size:255"`
+	SMTPPassword   string `gorm:"type:text"` // Secret credential
+	SMTPEncryption string `gorm:"size:20;default:'starttls'"` // starttls | tls | none
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // CaptchaProfile stores reusable captcha provider configuration.

--- a/internal/integrations/integrations_test.go
+++ b/internal/integrations/integrations_test.go
@@ -144,6 +144,54 @@ func TestUpdateMailerProfile(t *testing.T) {
 	})
 }
 
+func TestMailerProfileSMTPFields(t *testing.T) {
+	db := testsupport.SetupTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("persists SMTP fields on create", func(t *testing.T) {
+		params := integrations.MailerProfileParams{
+			Name:             "Test SMTP",
+			Provider:         "smtp",
+			DefaultFromName:  "Forms",
+			DefaultFromEmail: "forms@example.com",
+			SMTPHost:         "smtp.example.com",
+			SMTPPort:         587,
+			SMTPUsername:     "apikey",
+			SMTPPassword:     "s3cret",
+			SMTPEncryption:   "starttls",
+		}
+
+		profile, err := integrations.CreateMailerProfile(logger, db, params)
+		require.NoError(t, err)
+
+		reloaded, err := integrations.GetMailerProfileByID(db, profile.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "smtp", reloaded.Provider)
+		assert.Equal(t, "smtp.example.com", reloaded.SMTPHost)
+		assert.Equal(t, 587, reloaded.SMTPPort)
+		assert.Equal(t, "apikey", reloaded.SMTPUsername)
+		assert.Equal(t, "s3cret", reloaded.SMTPPassword)
+		assert.Equal(t, "starttls", reloaded.SMTPEncryption)
+	})
+
+	t.Run("updates SMTP fields", func(t *testing.T) {
+		profile, err := integrations.CreateMailerProfile(logger, db, integrations.MailerProfileParams{Name: "Update SMTP"})
+		require.NoError(t, err)
+
+		updated, err := integrations.UpdateMailerProfile(logger, db, profile.ID, integrations.MailerProfileParams{
+			Name:           "Update SMTP",
+			Provider:       "smtp",
+			SMTPHost:       "mail.example.org",
+			SMTPPort:       465,
+			SMTPEncryption: "tls",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "mail.example.org", updated.SMTPHost)
+		assert.Equal(t, 465, updated.SMTPPort)
+		assert.Equal(t, "tls", updated.SMTPEncryption)
+	})
+}
+
 func TestCreateCaptchaProfile(t *testing.T) {
 	db := testsupport.SetupTestDB(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/internal/integrations/mailers.go
+++ b/internal/integrations/mailers.go
@@ -20,6 +20,11 @@ type MailerProfileParams struct {
 	DefaultFromName  string
 	DefaultFromEmail string
 	DefaultsJSON     string
+	SMTPHost         string
+	SMTPPort         int
+	SMTPUsername     string
+	SMTPPassword     string
+	SMTPEncryption   string
 }
 
 // ValidationError represents a validation error
@@ -66,6 +71,11 @@ func CreateMailerProfile(logger *slog.Logger, db *gorm.DB, params MailerProfileP
 		DefaultFromName:  strings.TrimSpace(params.DefaultFromName),
 		DefaultFromEmail: strings.TrimSpace(params.DefaultFromEmail),
 		DefaultsJSON:     defaultsJSON,
+		SMTPHost:         strings.TrimSpace(params.SMTPHost),
+		SMTPPort:         params.SMTPPort,
+		SMTPUsername:     strings.TrimSpace(params.SMTPUsername),
+		SMTPPassword:     strings.TrimSpace(params.SMTPPassword),
+		SMTPEncryption:   strings.TrimSpace(params.SMTPEncryption),
 	}
 
 	if err := dbtxn.WithRetry(logger, db, func(tx *gorm.DB) error {
@@ -119,6 +129,11 @@ func UpdateMailerProfile(logger *slog.Logger, db *gorm.DB, id uint, params Maile
 			"default_from_name":  strings.TrimSpace(params.DefaultFromName),
 			"default_from_email": strings.TrimSpace(params.DefaultFromEmail),
 			"defaults_json":      defaultsJSON,
+			"smtp_host":          strings.TrimSpace(params.SMTPHost),
+			"smtp_port":          params.SMTPPort,
+			"smtp_username":      strings.TrimSpace(params.SMTPUsername),
+			"smtp_password":      strings.TrimSpace(params.SMTPPassword),
+			"smtp_encryption":    strings.TrimSpace(params.SMTPEncryption),
 		}).Error
 	}); err != nil {
 		logger.Error("failed to update mailer profile", slog.Any("error", err), slog.Uint64("id", uint64(id)))

--- a/internal/jobs/email.go
+++ b/internal/jobs/email.go
@@ -87,19 +87,19 @@ func (d *EmailDispatcher) handleEvent(ctx *JobContext, db *gorm.DB, event *forms
 
 	var sendErr error
 	switch profile.Provider {
-	case "smtp":
+	case "mailgun":
+		if profile.APIKey == "" || profile.Domain == "" {
+			MarkEmailAsFinal(ctx, db, event, forms.WebhookStatusFailed, "mailgun configuration missing")
+			return
+		}
+		sendErr = d.sendMailgun(ctx, profile, from, to, subject, body)
+	default: // smtp is the default provider
 		cfg := smtpConfigFromProfile(profile, from, to)
 		if cfg == nil {
 			MarkEmailAsFinal(ctx, db, event, forms.WebhookStatusFailed, "smtp configuration missing")
 			return
 		}
 		sendErr = sendSMTP(cfg, buildSMTPMessage(from, to, subject, body))
-	default: // mailgun
-		if profile.APIKey == "" || profile.Domain == "" {
-			MarkEmailAsFinal(ctx, db, event, forms.WebhookStatusFailed, "mailgun configuration missing")
-			return
-		}
-		sendErr = d.sendMailgun(ctx, profile, from, to, subject, body)
 	}
 
 	if sendErr != nil {

--- a/internal/jobs/email.go
+++ b/internal/jobs/email.go
@@ -76,126 +76,142 @@ func (d *EmailDispatcher) handleEvent(ctx *JobContext, db *gorm.DB, event *forms
 		return
 	}
 
-	cfg := d.resolveMailgunConfig(ctx, emailDelivery)
-	if cfg == nil {
-		MarkEmailAsFinal(ctx, db, event, forms.WebhookStatusFailed, "mailgun configuration missing")
+	profile, from, to := resolveProfileRecipients(db, emailDelivery)
+	if profile == nil || from == "" || to == "" {
+		MarkEmailAsFinal(ctx, db, event, forms.WebhookStatusFailed, "mailer configuration missing")
 		return
 	}
 
-	values, err := d.buildFormBody(event, cfg)
-	if err != nil {
-		MarkEmailAsRetry(ctx, db, event, d.retry, err)
+	subject := fmt.Sprintf("New submission · %s", event.Submission.Form.Name)
+	body := bodyForEvent(event)
+
+	var sendErr error
+	switch profile.Provider {
+	case "smtp":
+		cfg := smtpConfigFromProfile(profile, from, to)
+		if cfg == nil {
+			MarkEmailAsFinal(ctx, db, event, forms.WebhookStatusFailed, "smtp configuration missing")
+			return
+		}
+		sendErr = sendSMTP(cfg, buildSMTPMessage(from, to, subject, body))
+	default: // mailgun
+		if profile.APIKey == "" || profile.Domain == "" {
+			MarkEmailAsFinal(ctx, db, event, forms.WebhookStatusFailed, "mailgun configuration missing")
+			return
+		}
+		sendErr = d.sendMailgun(ctx, profile, from, to, subject, body)
+	}
+
+	if sendErr != nil {
+		MarkEmailAsRetry(ctx, db, event, d.retry, sendErr)
 		return
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.Endpoint(), strings.NewReader(values.Encode()))
-	if err != nil {
-		MarkEmailAsRetry(ctx, db, event, d.retry, err)
-		return
-	}
-
-	req.SetBasicAuth("api", cfg.APIKey)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("User-Agent", "Formlander/1.0")
-
-	resp, err := d.http.Do(req)
-	if err != nil {
-		MarkEmailAsRetry(ctx, db, event, d.retry, err)
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		MarkEmailAsRetry(ctx, db, event, d.retry, fmt.Errorf("unexpected status %d", resp.StatusCode))
-		return
-	}
-
-	updater := NewEventUpdater(&forms.EmailEvent{})
-	attemptCount := event.AttemptCount + 1
-	if err := updater.Update(ctx, db, event.ID, forms.WebhookStatusDelivered, time.Now(), "", WithAttemptCount(attemptCount), WithNextAttempt(nil)); err != nil {
-		ctx.Logger.Error("update email event", slog.Uint64("id", uint64(event.ID)), slog.Any("error", err))
-	} else {
-		event.Status = forms.WebhookStatusDelivered
-		event.AttemptCount = attemptCount
-		last := time.Now().UTC()
-		event.LastAttemptAt = &last
-		event.LastAttemptErr = ""
-		event.NextAttemptAt = nil
-	}
+	d.markEmailDelivered(ctx, db, event)
 }
 
-type mailgunConfig struct {
-	APIKey string
-	Domain string
-	From   string
-	To     string
-}
+// resolveProfileRecipients loads the mailer profile and resolves the From and
+// To addresses shared by every provider.
+func resolveProfileRecipients(db *gorm.DB, emailDelivery *forms.EmailDelivery) (*integrations.MailerProfile, string, string) {
+	if emailDelivery.MailerProfileID == nil {
+		return nil, "", ""
+	}
 
-func (m *mailgunConfig) Endpoint() string {
-	return fmt.Sprintf("https://api.mailgun.net/v3/%s/messages", m.Domain)
-}
+	var profile integrations.MailerProfile
+	if err := db.First(&profile, *emailDelivery.MailerProfileID).Error; err != nil {
+		return nil, "", ""
+	}
 
-func (d *EmailDispatcher) resolveMailgunConfig(ctx *JobContext, emailDelivery *forms.EmailDelivery) *mailgunConfig {
-	db := ctx.DB
-
-	// Resolve recipient from overrides_json or fallback
 	var to string
 	if emailDelivery.OverridesJSON != "" {
 		var overrides map[string]interface{}
 		if err := json.Unmarshal([]byte(emailDelivery.OverridesJSON), &overrides); err == nil {
-			if toField, ok := overrides["to"].(string); ok && toField != "" {
+			if toField, ok := overrides["to"].(string); ok {
 				to = toField
 			}
 		}
 	}
 
-	// If no mailer profile, can't send email
-	if emailDelivery.MailerProfileID == nil {
-		return nil
-	}
-
-	// Load the mailer profile
-	var profile integrations.MailerProfile
-	if err := db.First(&profile, *emailDelivery.MailerProfileID).Error; err != nil {
-		return nil
-	}
-
-	apiKey := profile.APIKey
-	domain := profile.Domain
 	from := profile.DefaultFromEmail
 	if profile.DefaultFromName != "" {
 		from = fmt.Sprintf("%s <%s>", profile.DefaultFromName, profile.DefaultFromEmail)
 	}
 
-	// Ensure we have all required config
-	if apiKey == "" || domain == "" || from == "" || to == "" {
+	return &profile, from, to
+}
+
+// smtpConfigFromProfile builds an SMTP send config from a mailer profile,
+// returning nil when required fields are missing.
+func smtpConfigFromProfile(profile *integrations.MailerProfile, from, to string) *smtpConfig {
+	if profile.SMTPHost == "" || profile.SMTPPort == 0 {
 		return nil
 	}
-
-	return &mailgunConfig{
-		APIKey: apiKey,
-		Domain: domain,
-		From:   from,
-		To:     to,
+	encryption := profile.SMTPEncryption
+	if encryption == "" {
+		encryption = "starttls"
+	}
+	return &smtpConfig{
+		Host:       profile.SMTPHost,
+		Port:       profile.SMTPPort,
+		Username:   profile.SMTPUsername,
+		Password:   profile.SMTPPassword,
+		Encryption: encryption,
+		From:       from,
+		To:         to,
 	}
 }
 
-func (d *EmailDispatcher) buildFormBody(event *forms.EmailEvent, cfg *mailgunConfig) (url.Values, error) {
+// sendMailgun delivers the message through the Mailgun HTTP API.
+func (d *EmailDispatcher) sendMailgun(ctx *JobContext, profile *integrations.MailerProfile, from, to, subject, body string) error {
+	values := url.Values{}
+	values.Set("from", from)
+	values.Set("to", to)
+	values.Set("subject", subject)
+	values.Set("text", body)
+
+	endpoint := fmt.Sprintf("https://api.mailgun.net/v3/%s/messages", profile.Domain)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth("api", profile.APIKey)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "Formlander/1.0")
+
+	resp, err := d.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// markEmailDelivered records a successful send on the event.
+func (d *EmailDispatcher) markEmailDelivered(ctx *JobContext, db *gorm.DB, event *forms.EmailEvent) {
+	updater := NewEventUpdater(&forms.EmailEvent{})
+	attemptCount := event.AttemptCount + 1
+	if err := updater.Update(ctx, db, event.ID, forms.WebhookStatusDelivered, time.Now(), "", WithAttemptCount(attemptCount), WithNextAttempt(nil)); err != nil {
+		ctx.Logger.Error("update email event", slog.Uint64("id", uint64(event.ID)), slog.Any("error", err))
+		return
+	}
+	event.Status = forms.WebhookStatusDelivered
+	event.AttemptCount = attemptCount
+	last := time.Now().UTC()
+	event.LastAttemptAt = &last
+	event.LastAttemptErr = ""
+	event.NextAttemptAt = nil
+}
+
+func bodyForEvent(event *forms.EmailEvent) string {
 	var payload map[string]any
 	if err := json.Unmarshal([]byte(event.Submission.DataJSON), &payload); err != nil {
 		payload = map[string]any{"raw": event.Submission.DataJSON}
 	}
-
-	subject := fmt.Sprintf("New submission · %s", event.Submission.Form.Name)
-	body := renderEmailBody(payload)
-
-	values := url.Values{}
-	values.Set("from", cfg.From)
-	values.Set("to", cfg.To)
-	values.Set("subject", subject)
-	values.Set("text", body)
-
-	return values, nil
+	return renderEmailBody(payload)
 }
 
 func renderEmailBody(payload map[string]any) string {

--- a/internal/jobs/smtp.go
+++ b/internal/jobs/smtp.go
@@ -1,0 +1,111 @@
+package jobs
+
+import (
+	"crypto/tls"
+	"net"
+	"net/mail"
+	"net/smtp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// smtpConfig holds the resolved settings for one SMTP send.
+type smtpConfig struct {
+	Host       string
+	Port       int
+	Username   string
+	Password   string
+	Encryption string // starttls | tls | none
+	From       string // header form, e.g. "Name <addr>"
+	To         string
+}
+
+// sendSMTP delivers a pre-built message via SMTP. TLS modes:
+//   - "tls":      implicit TLS from connect (typically port 465)
+//   - "starttls": upgrade the plaintext connection (typically port 587)
+//   - "none":     plaintext (port 25); auth is only allowed to localhost relays
+//
+// Certificates are always verified; credentials are never logged.
+func sendSMTP(cfg *smtpConfig, msg []byte) error {
+	addr := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+
+	var client *smtp.Client
+	if cfg.Encryption == "tls" {
+		conn, err := tls.Dial("tcp", addr, tlsConfigFor(cfg.Host))
+		if err != nil {
+			return err
+		}
+		client, err = smtp.NewClient(conn, cfg.Host)
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		client, err = smtp.Dial(addr)
+		if err != nil {
+			return err
+		}
+	}
+	defer client.Close()
+
+	if cfg.Encryption == "starttls" {
+		if err := client.StartTLS(tlsConfigFor(cfg.Host)); err != nil {
+			return err
+		}
+	}
+
+	if cfg.Username != "" {
+		auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+		if err := client.Auth(auth); err != nil {
+			return err
+		}
+	}
+
+	if err := client.Mail(envelopeAddr(cfg.From)); err != nil {
+		return err
+	}
+	if err := client.Rcpt(envelopeAddr(cfg.To)); err != nil {
+		return err
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(msg); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return client.Quit()
+}
+
+func tlsConfigFor(host string) *tls.Config {
+	return &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12}
+}
+
+// envelopeAddr extracts the bare address for MAIL FROM / RCPT TO, stripping any
+// display name. Falls back to the trimmed input if it can't be parsed.
+func envelopeAddr(s string) string {
+	if addr, err := mail.ParseAddress(s); err == nil {
+		return addr.Address
+	}
+	return strings.TrimSpace(s)
+}
+
+// buildSMTPMessage assembles a minimal RFC 5322 plain-text email message.
+// Header and body line endings are normalized to CRLF as required by SMTP.
+func buildSMTPMessage(from, to, subject, body string) []byte {
+	var b strings.Builder
+	b.WriteString("From: " + from + "\r\n")
+	b.WriteString("To: " + to + "\r\n")
+	b.WriteString("Subject: " + subject + "\r\n")
+	b.WriteString("Date: " + time.Now().UTC().Format(time.RFC1123Z) + "\r\n")
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(strings.ReplaceAll(body, "\n", "\r\n"))
+	return []byte(b.String())
+}

--- a/internal/jobs/smtp_test.go
+++ b/internal/jobs/smtp_test.go
@@ -2,11 +2,19 @@ package jobs
 
 import (
 	"bufio"
+	"context"
+	"io"
+	"log/slog"
 	"net"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"formlander/internal/config"
+	"formlander/internal/forms"
+	"formlander/internal/integrations"
+	"formlander/internal/pkg/testsupport"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,6 +143,62 @@ func TestSendSMTP(t *testing.T) {
 		assert.False(t, captured.authReceived, "expected no AUTH when username empty")
 		assert.Contains(t, captured.from, "a@x.com")
 	})
+}
+
+func TestEmailDispatcherDeliversViaSMTP(t *testing.T) {
+	db := testsupport.SetupTestDB(t)
+	host, port, captured := startFakeSMTPServer(t)
+
+	profile := &integrations.MailerProfile{
+		Name:             "SMTP relay",
+		Provider:         "smtp",
+		DefaultFromName:  "Forms",
+		DefaultFromEmail: "forms@example.com",
+		SMTPHost:         host,
+		SMTPPort:         port,
+		SMTPUsername:     "relay-user",
+		SMTPPassword:     "relay-pass",
+		SMTPEncryption:   "none",
+	}
+	require.NoError(t, db.Create(profile).Error)
+
+	form := &forms.Form{Name: "Contact", AllowedOrigins: "*"}
+	require.NoError(t, db.Create(form).Error)
+
+	pid := profile.ID
+	require.NoError(t, db.Create(&forms.EmailDelivery{
+		FormID:          form.ID,
+		Enabled:         true,
+		MailerProfileID: &pid,
+		OverridesJSON:   `{"to":"owner@example.com"}`,
+	}).Error)
+
+	sub := &forms.Submission{FormID: form.ID, DataJSON: `{"name":"Alice","email":"alice@example.com"}`}
+	require.NoError(t, db.Create(sub).Error)
+
+	event := &forms.EmailEvent{SubmissionID: sub.ID, Status: forms.WebhookStatusPending}
+	require.NoError(t, db.Create(event).Error)
+
+	d := NewEmailDispatcher(&config.Config{})
+	ctx := &JobContext{
+		Context: context.Background(),
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DB:      db,
+	}
+
+	require.NoError(t, d.ProcessBatch(ctx))
+
+	var updated forms.EmailEvent
+	require.NoError(t, db.First(&updated, event.ID).Error)
+	assert.Equal(t, forms.WebhookStatusDelivered, updated.Status, "event should be marked delivered")
+
+	captured.mu.Lock()
+	defer captured.mu.Unlock()
+	assert.True(t, captured.authReceived)
+	assert.Contains(t, captured.from, "forms@example.com")
+	assert.Contains(t, captured.to, "owner@example.com")
+	assert.Contains(t, captured.data, "Subject: New submission")
+	assert.Contains(t, captured.data, "Alice")
 }
 
 func TestBuildSMTPMessage(t *testing.T) {

--- a/internal/jobs/smtp_test.go
+++ b/internal/jobs/smtp_test.go
@@ -1,0 +1,174 @@
+package jobs
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturedMail records what a fake SMTP server received.
+type capturedMail struct {
+	mu           sync.Mutex
+	from         string
+	to           string
+	data         string
+	authReceived bool
+}
+
+// startFakeSMTPServer spins up a minimal plaintext SMTP server on a random
+// loopback port for one connection, capturing the envelope and message.
+func startFakeSMTPServer(t *testing.T) (host string, port int, captured *capturedMail) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	captured = &capturedMail{}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+		r := bufio.NewReader(conn)
+		write := func(s string) { _, _ = conn.Write([]byte(s + "\r\n")) }
+
+		write("220 fake ESMTP")
+		inData := false
+		var dataLines []string
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+
+			if inData {
+				if line == "." {
+					captured.mu.Lock()
+					captured.data = strings.Join(dataLines, "\n")
+					captured.mu.Unlock()
+					inData = false
+					write("250 OK queued")
+					continue
+				}
+				dataLines = append(dataLines, line)
+				continue
+			}
+
+			switch {
+			case strings.HasPrefix(line, "EHLO"), strings.HasPrefix(line, "HELO"):
+				write("250-fake greets you")
+				write("250 AUTH PLAIN LOGIN")
+			case strings.HasPrefix(line, "AUTH"):
+				captured.mu.Lock()
+				captured.authReceived = true
+				captured.mu.Unlock()
+				write("235 2.7.0 Authentication successful")
+			case strings.HasPrefix(line, "MAIL FROM:"):
+				captured.mu.Lock()
+				captured.from = line
+				captured.mu.Unlock()
+				write("250 OK")
+			case strings.HasPrefix(line, "RCPT TO:"):
+				captured.mu.Lock()
+				captured.to = line
+				captured.mu.Unlock()
+				write("250 OK")
+			case strings.HasPrefix(line, "DATA"):
+				write("354 End data with <CR><LF>.<CR><LF>")
+				inData = true
+			case strings.HasPrefix(line, "QUIT"):
+				write("221 Bye")
+				return
+			default:
+				write("250 OK")
+			}
+		}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	return "127.0.0.1", addr.Port, captured
+}
+
+func TestSendSMTP(t *testing.T) {
+	t.Run("delivers with PLAIN auth over plaintext", func(t *testing.T) {
+		host, port, captured := startFakeSMTPServer(t)
+		cfg := &smtpConfig{
+			Host: host, Port: port,
+			Username: "apikey", Password: "secret",
+			Encryption: "none",
+			From:       "Forms <forms@example.com>",
+			To:         "owner@example.com",
+		}
+		msg := buildSMTPMessage(cfg.From, cfg.To, "New submission", "name: Alice")
+
+		err := sendSMTP(cfg, msg)
+		require.NoError(t, err)
+
+		captured.mu.Lock()
+		defer captured.mu.Unlock()
+		assert.True(t, captured.authReceived, "expected AUTH command")
+		assert.Contains(t, captured.from, "forms@example.com")
+		assert.Contains(t, captured.to, "owner@example.com")
+		assert.Contains(t, captured.data, "Subject: New submission")
+		assert.Contains(t, captured.data, "name: Alice")
+	})
+
+	t.Run("skips auth when username empty", func(t *testing.T) {
+		host, port, captured := startFakeSMTPServer(t)
+		cfg := &smtpConfig{Host: host, Port: port, Encryption: "none", From: "a@x.com", To: "b@x.com"}
+
+		err := sendSMTP(cfg, buildSMTPMessage(cfg.From, cfg.To, "S", "B"))
+		require.NoError(t, err)
+
+		captured.mu.Lock()
+		defer captured.mu.Unlock()
+		assert.False(t, captured.authReceived, "expected no AUTH when username empty")
+		assert.Contains(t, captured.from, "a@x.com")
+	})
+}
+
+func TestBuildSMTPMessage(t *testing.T) {
+	t.Run("includes RFC 5322 headers and body", func(t *testing.T) {
+		msg := buildSMTPMessage("Forms <forms@example.com>", "owner@example.com", "New submission", "name: Alice\nemail: alice@x.com")
+
+		s := string(msg)
+		if !strings.Contains(s, "From: Forms <forms@example.com>\r\n") {
+			t.Errorf("missing From header, got:\n%s", s)
+		}
+		if !strings.Contains(s, "To: owner@example.com\r\n") {
+			t.Errorf("missing To header, got:\n%s", s)
+		}
+		if !strings.Contains(s, "Subject: New submission\r\n") {
+			t.Errorf("missing Subject header, got:\n%s", s)
+		}
+		if !strings.Contains(s, "MIME-Version: 1.0\r\n") {
+			t.Errorf("missing MIME-Version header, got:\n%s", s)
+		}
+		if !strings.Contains(s, "Content-Type: text/plain; charset=\"utf-8\"\r\n") {
+			t.Errorf("missing Content-Type header, got:\n%s", s)
+		}
+	})
+
+	t.Run("separates headers from body with a blank CRLF line", func(t *testing.T) {
+		msg := buildSMTPMessage("a@x.com", "b@x.com", "Hi", "line one\nline two")
+
+		s := string(msg)
+		if !strings.Contains(s, "\r\n\r\n") {
+			t.Errorf("expected blank line separating headers and body, got:\n%s", s)
+		}
+		// body newlines normalized to CRLF
+		if !strings.Contains(s, "line one\r\nline two") {
+			t.Errorf("expected body lines joined with CRLF, got:\n%s", s)
+		}
+	})
+}

--- a/web/templates/admin/mailers/new/content.html
+++ b/web/templates/admin/mailers/new/content.html
@@ -31,6 +31,7 @@
                     <select id="provider" name="provider" required
                         class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20">
                         <option value="mailgun" {{ if and .Profile (eq .Profile.Provider "mailgun") }}selected{{ end }}>Mailgun</option>
+                        <option value="smtp" {{ if and .Profile (eq .Profile.Provider "smtp") }}selected{{ end }}>SMTP</option>
                     </select>
                 </div>
             </div>
@@ -42,7 +43,8 @@
                 <h2 class="text-lg font-semibold text-gray-900">Provider Configuration</h2>
                 <p class="mt-1 text-sm text-gray-600">API credentials and domain settings</p>
             </div>
-            <div class="space-y-6 p-6">
+            <!-- Mailgun fields -->
+            <div data-config="mailgun" class="space-y-6 p-6">
                 <div>
                     <label for="api_key" class="block text-sm font-medium text-gray-700">API Key</label>
                     <input type="password" id="api_key" name="api_key" value="{{ if .Profile }}{{ .Profile.APIKey }}{{ end }}"
@@ -55,6 +57,49 @@
                     <input type="text" id="domain" name="domain" value="{{ if .Profile }}{{ .Profile.Domain }}{{ end }}"
                         class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
                         placeholder="mg.example.com">
+                </div>
+            </div>
+
+            <!-- SMTP fields -->
+            <div data-config="smtp" class="space-y-6 p-6">
+                <div>
+                    <label for="smtp_host" class="block text-sm font-medium text-gray-700">SMTP Host</label>
+                    <input type="text" id="smtp_host" name="smtp_host" value="{{ if .Profile }}{{ .Profile.SMTPHost }}{{ end }}"
+                        class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                        placeholder="smtp.example.com">
+                </div>
+
+                <div>
+                    <label for="smtp_port" class="block text-sm font-medium text-gray-700">Port</label>
+                    <input type="number" id="smtp_port" name="smtp_port" value="{{ if and .Profile .Profile.SMTPPort }}{{ .Profile.SMTPPort }}{{ else }}587{{ end }}"
+                        class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                        placeholder="587">
+                    <p class="mt-1 text-xs text-gray-500">587 (STARTTLS), 465 (TLS), or 25 (none)</p>
+                </div>
+
+                <div>
+                    <label for="smtp_encryption" class="block text-sm font-medium text-gray-700">Encryption</label>
+                    <select id="smtp_encryption" name="smtp_encryption"
+                        class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20">
+                        <option value="starttls" {{ if and .Profile (eq .Profile.SMTPEncryption "starttls") }}selected{{ end }}>STARTTLS</option>
+                        <option value="tls" {{ if and .Profile (eq .Profile.SMTPEncryption "tls") }}selected{{ end }}>TLS (implicit)</option>
+                        <option value="none" {{ if and .Profile (eq .Profile.SMTPEncryption "none") }}selected{{ end }}>None</option>
+                    </select>
+                </div>
+
+                <div>
+                    <label for="smtp_username" class="block text-sm font-medium text-gray-700">Username</label>
+                    <input type="text" id="smtp_username" name="smtp_username" value="{{ if .Profile }}{{ .Profile.SMTPUsername }}{{ end }}"
+                        class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                        placeholder="user@example.com">
+                    <p class="mt-1 text-xs text-gray-500">Leave blank for an unauthenticated relay</p>
+                </div>
+
+                <div>
+                    <label for="smtp_password" class="block text-sm font-medium text-gray-700">Password</label>
+                    <input type="password" id="smtp_password" name="smtp_password" value="{{ if .Profile }}{{ .Profile.SMTPPassword }}{{ end }}"
+                        class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 font-mono text-sm shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                        placeholder="••••••••">
                 </div>
             </div>
         </div>
@@ -108,4 +153,19 @@
         </div>
     </form>
 </div>
+
+<script>
+(function () {
+    var sel = document.getElementById("provider");
+    if (!sel) return;
+    var groups = document.querySelectorAll("[data-config]");
+    function sync() {
+        groups.forEach(function (g) {
+            g.style.display = g.getAttribute("data-config") === sel.value ? "" : "none";
+        });
+    }
+    sel.addEventListener("change", sync);
+    sync();
+})();
+</script>
 {{ end }}

--- a/web/templates/admin/mailers/new/content.html
+++ b/web/templates/admin/mailers/new/content.html
@@ -30,8 +30,8 @@
                     <label for="provider" class="block text-sm font-medium text-gray-700">Provider</label>
                     <select id="provider" name="provider" required
                         class="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20">
+                        <option value="smtp" {{ if or (not .Profile) (eq .Profile.Provider "smtp") }}selected{{ end }}>SMTP</option>
                         <option value="mailgun" {{ if and .Profile (eq .Profile.Provider "mailgun") }}selected{{ end }}>Mailgun</option>
-                        <option value="smtp" {{ if and .Profile (eq .Profile.Provider "smtp") }}selected{{ end }}>SMTP</option>
                     </select>
                 </div>
             </div>

--- a/web/templates/admin/mailers/show/content.html
+++ b/web/templates/admin/mailers/show/content.html
@@ -53,6 +53,20 @@
         <dt class="text-sm font-medium text-gray-500">Provider</dt>
         <dd class="mt-1 text-base font-medium text-gray-900">{{ .Profile.Provider }}</dd>
       </div>
+      {{ if eq .Profile.Provider "smtp" }}
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Host</dt>
+        <dd class="mt-1 text-base font-mono text-gray-900">{{ .Profile.SMTPHost }}:{{ .Profile.SMTPPort }}</dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Encryption</dt>
+        <dd class="mt-1 text-base text-gray-900">{{ .Profile.SMTPEncryption }}</dd>
+      </div>
+      <div class="sm:col-span-2">
+        <dt class="text-sm font-medium text-gray-500">Username</dt>
+        <dd class="mt-1 text-base font-mono text-gray-900">{{ if .Profile.SMTPUsername }}{{ .Profile.SMTPUsername }}{{ else }}<span class="text-gray-400">None (unauthenticated)</span>{{ end }}</dd>
+      </div>
+      {{ else }}
       <div>
         <dt class="text-sm font-medium text-gray-500">Domain</dt>
         <dd class="mt-1 text-base font-mono text-gray-900">{{ .Profile.Domain }}</dd>
@@ -68,6 +82,7 @@
         </dd>
         <input type="hidden" id="apiKeyValue" value="{{ .Profile.APIKey }}">
       </div>
+      {{ end }}
     </div>
   </div>
 


### PR DESCRIPTION
Adds SMTP as an alternative email provider alongside Mailgun. Each mailer profile is either Mailgun or SMTP, selected per profile.

## Changes
- **Model:** `MailerProfile` gains typed SMTP columns (host, port, username, password, encryption). Mailgun profiles leave them null and vice-versa.
- **Dispatch:** `EmailDispatcher` branches on `profile.Provider` — SMTP profiles send via the stdlib `net/smtp` (STARTTLS / implicit TLS / none, PLAIN auth); the Mailgun HTTP path is preserved verbatim.
- **UI:** "SMTP" option in the provider dropdown plus SMTP config fields on the new/edit form (shown for the selected provider, with a no-JS fallback); the show page renders SMTP details for SMTP profiles.

## Notes
- **No new dependencies** — stdlib `net/smtp` + `crypto/tls`. Certificates verified, TLS min 1.2; credentials never logged.

## Verification
- Unit: RFC 5322 message builder, `sendSMTP` against an in-test SMTP server (PLAIN auth).
- Integration: full `ProcessBatch` → SMTP delivery to a fake server, asserting the event is marked delivered.

Closes #32
