### PR TITLE
forms: honor the documented __fl_hp honeypot

### DIFF
--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -245,6 +245,67 @@ func TestCreateSubmission(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "{}", submission.DataJSON)
 	})
+
+	t.Run("honeypot field marks submission as spam and skips deliveries", func(t *testing.T) {
+		db9 := testsupport.SetupTestDB(t)
+
+		form := &forms.Form{Name: "Honeypot Form", Slug: "honeypot"}
+		require.NoError(t, db9.Create(form).Error)
+		require.NoError(t, db9.Create(&forms.WebhookDelivery{
+			FormID:  form.ID,
+			Enabled: true,
+			URL:     "https://example.com/hook",
+		}).Error)
+		require.NoError(t, db9.Create(&forms.EmailDelivery{
+			FormID:        form.ID,
+			Enabled:       true,
+			OverridesJSON: `{"to": "owner@example.com"}`,
+		}).Error)
+		require.NoError(t, db9.
+			Preload("WebhookDelivery").Preload("EmailDelivery").
+			First(form, form.ID).Error)
+
+		payload := map[string]any{
+			"name":    "Botty",
+			"email":   "bot@spam.example",
+			"__fl_hp": "i-am-a-bot",
+		}
+
+		submission, err := forms.CreateSubmission(logger, db9, form, payload, "BotAgent")
+		require.NoError(t, err)
+		assert.True(t, submission.IsSpam, "filled honeypot should mark IsSpam=true")
+
+		// Stored payload should not include the honeypot field.
+		var stored map[string]any
+		require.NoError(t, json.Unmarshal([]byte(submission.DataJSON), &stored))
+		assert.NotContains(t, stored, "__fl_hp", "honeypot field must be scrubbed from stored data")
+
+		// No delivery events should be enqueued for spam.
+		var webhookEvents []forms.WebhookEvent
+		require.NoError(t, db9.Where("submission_id = ?", submission.ID).Find(&webhookEvents).Error)
+		assert.Len(t, webhookEvents, 0, "no webhook event for spam")
+
+		var emailEvents []forms.EmailEvent
+		require.NoError(t, db9.Where("submission_id = ?", submission.ID).Find(&emailEvents).Error)
+		assert.Len(t, emailEvents, 0, "no email event for spam")
+	})
+
+	t.Run("empty honeypot field does not mark spam", func(t *testing.T) {
+		db10 := testsupport.SetupTestDB(t)
+
+		form := &forms.Form{Name: "Real User Form", Slug: "real-user"}
+		require.NoError(t, db10.Create(form).Error)
+
+		// Real users leave the honeypot blank — must not trigger spam.
+		payload := map[string]any{
+			"name":    "Alice",
+			"__fl_hp": "",
+		}
+
+		submission, err := forms.CreateSubmission(logger, db10, form, payload, "RealUser")
+		require.NoError(t, err)
+		assert.False(t, submission.IsSpam, "empty honeypot must not flag spam")
+	})
 }
 
 func TestSlugify(t *testing.T) {

--- a/internal/forms/submissions.go
+++ b/internal/forms/submissions.go
@@ -3,6 +3,7 @@ package forms
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"log/slog"
@@ -12,12 +13,35 @@ import (
 	"formlander/internal/pkg/dbtxn"
 )
 
+// HoneypotField is the form field name reserved for bot-trap detection.
+// Real users leave it empty; bots that fill out every field expose themselves.
+// Submissions where this field has a non-empty value are stored as spam and
+// not forwarded to webhooks or email.
+const HoneypotField = "__fl_hp"
+
 // SubmissionParams holds parameters for creating a submission
 type SubmissionParams struct {
 	FormID    uint
 	DataJSON  string
 	UserAgent string
 	IsSpam    bool
+}
+
+// checkHoneypot returns true when the payload's honeypot field is filled in,
+// and removes the field from the payload so it never reaches storage.
+func checkHoneypot(payload map[string]any) bool {
+	v, ok := payload[HoneypotField]
+	if !ok {
+		return false
+	}
+	delete(payload, HoneypotField)
+	if s, isStr := v.(string); isStr {
+		return strings.TrimSpace(s) != ""
+	}
+	// Any non-string value still counts as "filled" (bots sometimes
+	// submit arrays or other shapes for fields they were never meant
+	// to touch).
+	return v != nil
 }
 
 // CreateSubmission creates a new submission and associated delivery events
@@ -27,6 +51,8 @@ func CreateSubmission(logger *slog.Logger, db *gorm.DB, form *Form, payload map[
 
 // CreateSubmissionWithFiles creates a submission with optional file uploads
 func CreateSubmissionWithFiles(logger *slog.Logger, db *gorm.DB, form *Form, payload map[string]any, userAgent string, dataDir string, files []*UploadedFile) (*Submission, error) {
+	isSpam := checkHoneypot(payload)
+
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		logger.Error("encode submission payload", slog.Any("error", err))
@@ -38,7 +64,7 @@ func CreateSubmissionWithFiles(logger *slog.Logger, db *gorm.DB, form *Form, pay
 		DataJSON:  string(encoded),
 		IPHash:    "", // Not stored for privacy - only used for rate limiting
 		UserAgent: userAgent,
-		IsSpam:    false,
+		IsSpam:    isSpam,
 	}
 
 	if err := dbtxn.WithRetry(logger, db, func(tx *gorm.DB) error {
@@ -61,23 +87,27 @@ func CreateSubmissionWithFiles(logger *slog.Logger, db *gorm.DB, form *Form, pay
 			submission.Files = fileRecords
 		}
 
-		// Check webhook delivery
-		webhookDelivery := form.WebhookDelivery
-		if webhookDelivery != nil && webhookDelivery.Enabled && webhookDelivery.URL != "" {
-			event := NewWebhookEvent(submission.ID, time.Now().UTC())
-			if err := tx.Create(event).Error; err != nil {
-				return err
-			}
-		}
-
-		// Check email delivery
-		emailDelivery := form.EmailDelivery
-		if emailDelivery != nil && emailDelivery.Enabled {
-			recipient := extractEmailRecipient(emailDelivery)
-			if recipient != "" {
-				event := NewEmailEvent(submission.ID, time.Now().UTC())
+		// Spam submissions are stored but never forwarded — the bot sees a
+		// success response while the honeypot quietly contains it.
+		if !isSpam {
+			// Check webhook delivery
+			webhookDelivery := form.WebhookDelivery
+			if webhookDelivery != nil && webhookDelivery.Enabled && webhookDelivery.URL != "" {
+				event := NewWebhookEvent(submission.ID, time.Now().UTC())
 				if err := tx.Create(event).Error; err != nil {
 					return err
+				}
+			}
+
+			// Check email delivery
+			emailDelivery := form.EmailDelivery
+			if emailDelivery != nil && emailDelivery.Enabled {
+				recipient := extractEmailRecipient(emailDelivery)
+				if recipient != "" {
+					event := NewEmailEvent(submission.ID, time.Now().UTC())
+					if err := tx.Create(event).Error; err != nil {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The README and `formlander.com/docs/security` advertise a honeypot field (`__fl_hp`), but the backend was ignoring it — submissions that filled it still went through and triggered email/webhook deliveries (reported in #45).

## Fix
`forms.CreateSubmissionWithFiles` now checks for the honeypot in every submission:

- Any non-empty value in `__fl_hp` → `submission.IsSpam = true`.
- The field is **scrubbed** from the stored payload (it isn't real form data).
- **No webhook or email events** are enqueued for spam submissions.
- The HTTP handler still returns a normal 2xx (and follows `_success_url` if set), so the bot can't tell its submission was trapped.

Real users — who leave the field empty or omit it entirely — are unaffected; existing test coverage stays green.

## Tests
Two new subtests in `TestCreateSubmission`:
- `honeypot field marks submission as spam and skips deliveries` — full check (IsSpam, scrubbed payload, no webhook event, no email event) against a form with both deliveries enabled.
- `empty honeypot field does not mark spam` — guards against false positives.

## Notes / follow-ups
- This is the "automatic, no config" honeypot (per the DHH/subtract lens). The docs language at `formlander.com/docs/security` calls it "configurable" — worth a tiny copy tweak in a follow-up.
- The dashboard's form HTML snippet doesn't yet include `__fl_hp` automatically; users still add it themselves per the docs. A future polish: auto-include it in copy-paste snippets so users get protection by default.

Closes #45
