### PR TITLE
ui: drop hardcoded 'Mailgun' from form and submission pages

### DIFF
--- a/web/templates/admin/forms/new.html
+++ b/web/templates/admin/forms/new.html
@@ -193,13 +193,7 @@
         <!-- Email Forwarding -->
         <div class="rounded-xl border border-gray-200 bg-white shadow-sm">
             <div class="border-b border-gray-200 px-6 py-4">
-                <div class="flex items-center">
-                    <h2 class="text-lg font-semibold text-gray-900">Email Forwarding</h2>
-                    <span
-                        class="ml-3 inline-flex items-center rounded-md bg-purple-50 px-2 py-1 text-xs font-mono text-purple-700 ring-1 ring-inset ring-purple-600/20">
-                        Mailgun
-                    </span>
-                </div>
+                <h2 class="text-lg font-semibold text-gray-900">Email Forwarding</h2>
                 <p class="mt-1 text-sm text-gray-600">Send submissions to an email address</p>
             </div>
             <div class="p-6 space-y-6">

--- a/web/templates/admin/submissions/show.html
+++ b/web/templates/admin/submissions/show.html
@@ -172,7 +172,7 @@
     <div class="rounded-xl border border-gray-200 bg-white shadow-sm">
         <div class="border-b border-gray-200 px-6 py-4">
             <h2 class="text-lg font-semibold text-gray-900">Email Deliveries</h2>
-            <p class="text-sm text-gray-500">Notification emails sent via Mailgun</p>
+            <p class="text-sm text-gray-500">Notification emails sent for this submission</p>
         </div>
         <div class="divide-y divide-gray-200">
             {{ range .Submission.EmailEvents }}


### PR DESCRIPTION
After SMTP shipped, two spots in the admin UI still implied Mailgun was the only email provider — a 'Mailgun' pill on the form edit page and a 'sent via Mailgun' subtitle on submission detail. Removed/generalized both. Only the intentional Mailgun references (the provider dropdown option in the mailer profile form) remain.

Closes #46