### PR TITLE
forms: harden honeypot — skip file save for spam, log triggers

### DIFF
--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -1,7 +1,10 @@
 package forms_test
 
 import (
+	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"formlander/internal/forms"
@@ -288,6 +291,42 @@ func TestCreateSubmission(t *testing.T) {
 		var emailEvents []forms.EmailEvent
 		require.NoError(t, db9.Where("submission_id = ?", submission.ID).Find(&emailEvents).Error)
 		assert.Len(t, emailEvents, 0, "no email event for spam")
+	})
+
+	t.Run("honeypot-trapped submission does not save uploaded files", func(t *testing.T) {
+		db11 := testsupport.SetupTestDB(t)
+		dataDir := t.TempDir()
+
+		form := &forms.Form{Name: "File Form", Slug: "file-form"}
+		require.NoError(t, db11.Create(form).Error)
+
+		payload := map[string]any{
+			"name":    "Botty",
+			"__fl_hp": "i-am-a-bot",
+		}
+		files := []*forms.UploadedFile{{
+			FieldName:   "attachment",
+			Filename:    "payload.bin",
+			ContentType: "application/octet-stream",
+			Size:        4,
+			Data:        bytes.NewReader([]byte("junk")),
+		}}
+
+		submission, err := forms.CreateSubmissionWithFiles(logger, db11, form, payload, "BotAgent", dataDir, files)
+		require.NoError(t, err)
+		assert.True(t, submission.IsSpam, "filled honeypot must mark spam")
+		assert.Empty(t, submission.Files, "spam submission must not attach files")
+
+		// No file rows persisted.
+		var fileRows []forms.SubmissionFile
+		require.NoError(t, db11.Where("submission_id = ?", submission.ID).Find(&fileRows).Error)
+		assert.Len(t, fileRows, 0, "no SubmissionFile rows for spam")
+
+		// And no bytes were written to disk for this form/submission.
+		formDir := filepath.Join(dataDir, "forms")
+		if entries, err := os.ReadDir(formDir); err == nil {
+			assert.Len(t, entries, 0, "spam must not write to dataDir")
+		}
 	})
 
 	t.Run("empty honeypot field does not mark spam", func(t *testing.T) {

--- a/internal/forms/submissions.go
+++ b/internal/forms/submissions.go
@@ -52,6 +52,14 @@ func CreateSubmission(logger *slog.Logger, db *gorm.DB, form *Form, payload map[
 // CreateSubmissionWithFiles creates a submission with optional file uploads
 func CreateSubmissionWithFiles(logger *slog.Logger, db *gorm.DB, form *Form, payload map[string]any, userAgent string, dataDir string, files []*UploadedFile) (*Submission, error) {
 	isSpam := checkHoneypot(payload)
+	if isSpam {
+		// Operator visibility into honeypot activity. Info-level so it
+		// can be filtered out at scale but is on by default.
+		logger.Info("honeypot triggered",
+			slog.Uint64("form_id", uint64(form.ID)),
+			slog.String("form_slug", form.Slug),
+		)
+	}
 
 	encoded, err := json.Marshal(payload)
 	if err != nil {
@@ -72,8 +80,11 @@ func CreateSubmissionWithFiles(logger *slog.Logger, db *gorm.DB, form *Form, pay
 			return err
 		}
 
-		// Save files to disk and create records
-		if len(files) > 0 && dataDir != "" {
+		// Save files to disk and create records.
+		// Spam submissions don't save files: the bot got its 2xx, but we
+		// don't want to give it a free disk-fill vector for forms that
+		// accept uploads.
+		if !isSpam && len(files) > 0 && dataDir != "" {
 			fileRecords, err := SaveFiles(dataDir, form.ID, submission.ID, files)
 			if err != nil {
 				return fmt.Errorf("failed to save files: %w", err)

--- a/internal/pkg/testsupport/db.go
+++ b/internal/pkg/testsupport/db.go
@@ -30,6 +30,7 @@ func SetupTestDB(t *testing.T) *gorm.DB {
 		&forms.WebhookDelivery{},
 		&forms.WebhookEvent{},
 		&forms.EmailEvent{},
+		&forms.SubmissionFile{},
 		// Integrations
 		&integrations.MailerProfile{},
 		&integrations.CaptchaProfile{},


### PR DESCRIPTION
Two follow-ups from a self-review of #45 (v3.0.9):

## 1. Spam submissions no longer save uploaded files
The original honeypot fix gated *delivery events* on `!isSpam` but left the file-save block alone. For forms that accept uploads, a bot could still flood disk while looking like a normal trapped spam submission.

`CreateSubmissionWithFiles` now skips the file-save block (no `SaveFiles` call, no `SubmissionFile` rows, `submission.Files` stays empty) when the honeypot is triggered.

## 2. Honeypot triggers now log
Previously the honeypot was entirely silent — operators had no signal at all that bots were hitting them. Adds one `slog.Info("honeypot triggered", ...)` line on each trip with `form_id` + `form_slug`. On by default; info-level so it can be filtered at scale if it ever gets noisy.

## Infra
- Added `SubmissionFile` to `testsupport.SetupTestDB`'s migrations (was missing — any test that exercised the file path would have died with "no such table").
- New test: `TestCreateSubmission/honeypot-trapped_submission_does_not_save_uploaded_files` exercises files + payload + honeypot end-to-end and asserts no rows, no files attached, and no bytes in dataDir.

Related: #45.
